### PR TITLE
Rename NFC error events

### DIFF
--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -214,7 +214,7 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
                 )
             }
         } catch (throwable: Throwable) {
-            callback?.onEvent(Event(EventError.CANT_STOP_NFC))
+            callback?.onEvent(Event(EventError.START_NFC_ERROR))
         }
 
     }
@@ -227,7 +227,7 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
             nfcAdapter?.disableReaderMode(activity)
 
         } catch (throwable: Throwable) {
-            callback?.onEvent(Event(EventError.CANT_STOP_NFC))
+            callback?.onEvent(Event(EventError.STOP_NFC_ERROR))
         }
     }
 

--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/event/CieIDEvent.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/event/CieIDEvent.kt
@@ -28,8 +28,8 @@ interface  EventEnum
         GENERAL_ERROR,
         PIN_INPUT_ERROR,
         ON_NO_INTERNET_CONNECTION,
-        CANT_STOP_NFC,
-        CANT_START_NFC;
+        STOP_NFC_ERROR,
+        START_NFC_ERROR;
 
     }
 


### PR DESCRIPTION
This PR renames NFC error events with **_ERROR_** suffix and changes the error type threw in **_startNFCListening_** method