### PR TITLE
Removing code Redundancies﻿

### DIFF
--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/nfc/Ias.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/nfc/Ias.kt
@@ -617,8 +617,8 @@ internal class Ias constructor(val isoDep: IsoDep) {
     @Throws(Exception::class)
     fun getIdServizi(): String {
         CieIDSdkLogger.log("getIdServizi()")
-        transmit("00A4040C0DA0000000308000000009816001".hexStringToByteArray())
-        transmit("00A4040406A00000000039".hexStringToByteArray())
+        selectAidIas()
+        selectAidCie()
         transmit("00a40204021001".hexStringToByteArray())
         val res = transmit("00b000000c".hexStringToByteArray())
         if (res.swHex != "9000") {

--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/nfc/Ias.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/nfc/Ias.kt
@@ -588,6 +588,10 @@ internal class Ias constructor(val isoDep: IsoDep) {
         }
     }
 
+    init {
+        selectAidIas()
+        selectAidCie()
+    }
 
     /**
      * inizializza un canale sicuro tra carta e dispositivo passando il pin dell'utente
@@ -596,8 +600,6 @@ internal class Ias constructor(val isoDep: IsoDep) {
      */
     @Throws(Exception::class)
     fun startSecureChannel(pin: String) {
-        selectAidIas()
-        selectAidCie()
         initDHParam()
         if (dappPubKey.isEmpty())
             readDappPubKey()
@@ -617,8 +619,6 @@ internal class Ias constructor(val isoDep: IsoDep) {
     @Throws(Exception::class)
     fun getIdServizi(): String {
         CieIDSdkLogger.log("getIdServizi()")
-        selectAidIas()
-        selectAidCie()
         transmit("00a40204021001".hexStringToByteArray())
         val res = transmit("00b000000c".hexStringToByteArray())
         if (res.swHex != "9000") {


### PR DESCRIPTION
`selectAidIas()` and `selectAidCie()` were called twice and in two different way.