### PR TITLE
Add Kotlin test missing dependency and fix test dir tree (fix build)

### DIFF
--- a/cieidsdk/build.gradle
+++ b/cieidsdk/build.gradle
@@ -29,6 +29,11 @@ android {
             debuggable true
         }
     }
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+        }
+    }
 }
 
 
@@ -54,6 +59,8 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.2.19'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
 
-
+    // Kotlintest
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'io.kotlintest:kotlintest-runner-junit5:3.4.2'
 }
 

--- a/cieidsdk/src/test/java/it/ipzs/cieidsdk/test.apilevel.kt
+++ b/cieidsdk/src/test/java/it/ipzs/cieidsdk/test.apilevel.kt
@@ -1,11 +1,10 @@
-package tests
+package it.ipzs.cieidsdk
 
 import io.kotlintest.specs.FreeSpec
-import io.kotlintest.specs.StringSpec
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import android.os.Build
-import io.kotlintest.matchers.shouldBe
+import io.kotlintest.shouldBe
 import it.ipzs.cieidsdk.common.CieIDSdk
 
 

--- a/cieidsdk/src/test/java/it/ipzs/cieidsdk/test.pin.kt
+++ b/cieidsdk/src/test/java/it/ipzs/cieidsdk/test.pin.kt
@@ -1,6 +1,6 @@
-package tests
+package it.ipzs.cieidsdk
 
-import io.kotlintest.matchers.*
+import io.kotlintest.*
 import io.kotlintest.specs.StringSpec
 import it.ipzs.cieidsdk.common.CieIDSdk
 
@@ -29,7 +29,7 @@ class Pin : StringSpec({
     // with a char
     val wrongPin2 = "123a5678"
     fun setWrongPin2(){CieIDSdk.pin = wrongPin2}
-    "should throw an illegal argument exception"{
+    "should throw an illegal argument exception 2"{
         shouldThrow<IllegalArgumentException> {
             setWrongPin2()
         }


### PR DESCRIPTION
`io.kotlintest` dependency specification was missing in the current master branch. Also, the test code was misplaced. Both these issues prevent a successful build: https://jitpack.io/com/github/italia/cieid-android-sdk/b5a7baef9e/build.log

This pull request adds the missing dependency for `io.kotlintest` and move test files to the right path (in SDK library), so both Android Studio and `gradle` tool can distinguish between tests and actual code.

Note that I slightly modified imports in both test files to upgrade them to Kotlintest 3.4, as I can't make the 3.2 works.

These fixes also enables this repo to be included directly in Android Studio using https://jitpack.io/ (no need to publish this library in a maven repo)