### PR TITLE
Check extended APDU

### DIFF
--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -150,6 +150,15 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
             val isoDep = IsoDep.get(tag)
             isoDep.timeout = isoDepTimeout
             isoDep.connect()
+
+            if(isoDep.isExtendedLengthApduSupported){
+                CieIDSdkLogger.log("isExtendedLengthApduSupported : true")
+            }else{
+                CieIDSdkLogger.log("isExtendedLengthApduSupported : false")
+                callback?.onEvent(Event(EventSmartphone.EXTENDED_APDU_NOT_SUPPORTED))
+                return
+            }
+
             ias = Ias(isoDep)
             ias!!.getIdServizi()
             ias!!.startSecureChannel(ciePin)

--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/event/CieIDEvent.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/event/CieIDEvent.kt
@@ -8,8 +8,11 @@ interface  EventEnum
         ON_TAG_DISCOVERED_NOT_CIE,
         ON_TAG_DISCOVERED,
         ON_TAG_LOST;
-
     }
+    enum class EventSmartphone : EventEnum {
+        EXTENDED_APDU_NOT_SUPPORTED
+    }
+
     enum class EventCard: EventEnum {
         //card
         ON_CARD_PIN_LOCKED,


### PR DESCRIPTION
Added check on NFC compatibility with extended APDU, it is mandatory to comunicate with CIE. We suggest to check this error, we know that there are no compatibility on some Oppo and Realme devices.