### PR TITLE
An handled exception causes crash

### DIFF
--- a/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/cieidsdk/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -75,6 +75,12 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
             put(IdpService.authnRequest, deepLinkInfo.authnRequest ?: "")
             put(IdpService.generaCodice, "1")
         }
+        
+        // handling all swallowed exception
+        RxJavaPlugins.setErrorHandler { error -> run {
+        CieIDSdkLogger.log("error handled by RxJavaPlugins $error")
+        callback?.onError(error)
+        }}
 
         idpService.callIdp(mapValues).subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())


### PR DESCRIPTION
This PR adds the handling of exception that could cause crash
This could happen when the authorization URL is not valid (it depends on how it is set from outside)

### how to reproduce
- force the authorization URI to this invalid URI (`setUrl(url)`)
```
https://idserver.servizicie.interno.gov.it/OpenApp?nextUrl=https://idserver.servizicie.interno.gov.it/idp/Authn/X509&name=conversation&value=e1s2&authnRequestString=_ec725700fad278600a2a&OpText=Inserisci le ultime 4 cifre del PIN ricevute insieme alla tua Carta di Identità Elettronica per accedere a https://app-backend.io.italia.it&imgUrl=https://idserver.servizicie.interno.gov.it/idpimages/cielogo.pngshould
```
- set the PIN of your CIE card
- read your NFC card
- 💥 

⛑️  special thanks to @fabriziofff to find this issue